### PR TITLE
feat: 133101 restart nlportal backend app on config save

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -21,6 +21,7 @@ val guavaVersion = "33.4.0-jre"
 val springCloudServerVersion = "4.2.0"
 val springSecurityOauth2Version = "6.4.2"
 val kotlinLoggingVersion = "7.0.3"
+val mockitoAgent = configurations.create("mockitoAgent")
 
 plugins {
     kotlin("jvm") version "1.9.25"
@@ -65,7 +66,11 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("org.mockito:mockito-core:5.16.1")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    mockitoAgent("org.mockito:mockito-core:5.16.1") { isTransitive = false }
 }
 
 kotlin {
@@ -82,14 +87,17 @@ tasks.bootRun {
             "spring.datasource.username" to "config",
             "spring.datasource.password" to "password",
             "logging.level.root" to "DEBUG",
+            "JWT_ISSUER_URI" to "http://localhost:8082/auth/realms/nlportalconfig",
             "CONFIG_CACHE_TTL" to "30000",
-            "CONFIGURATION_SERVER_PREFIX" to "/configuration",
-            "CONFIGURATION_SERVER_TOKEN" to "VerySecretToken",
-            "JWT_ISSUER_URI" to "http://localhost:8082/auth/realms/nlportalconfig"
+            "CONFIG_SERVER_PREFIX" to "/configuration",
+            "CONFIG_SERVER_TOKEN" to "VerySecretToken",
+            "CONFIG_NOTIFY_ENABLED" to "true",
+            "CONFIG_NOTIFY_LIST" to "http://localhost:8090/, https://example.com",
         )
     )
 }
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    jvmArgs("-javaagent:${mockitoAgent.asPath}")
 }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -92,7 +92,7 @@ tasks.bootRun {
             "CONFIG_SERVER_PREFIX" to "/configuration",
             "CONFIG_SERVER_TOKEN" to "VerySecretToken",
             "CONFIG_NOTIFY_ENABLED" to "true",
-            "CONFIG_NOTIFY_LIST" to "http://localhost:8090/, https://example.com",
+            "CONFIG_NOTIFY_LIST" to "http://localhost:8090/",
         )
     )
 }

--- a/backend/src/main/kotlin/nl/nlportal/configurationpanel/client/NlPortalClient.kt
+++ b/backend/src/main/kotlin/nl/nlportal/configurationpanel/client/NlPortalClient.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nl.nlportal.configurationpanel.client
+
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+
+@Component
+class NlPortalClient {
+
+    fun restartNlPortalViaActuator(nlPortalBaseUrl: String) {
+        val restClient = RestClient.create(nlPortalBaseUrl)
+
+        restClient
+            .post()
+            .uri { builder ->
+                builder.path("/actuator/restart").build()
+            }
+            .body(emptyMap<String, String>())
+            .contentType(MediaType.APPLICATION_JSON)
+            .retrieve()
+            .toBodilessEntity()
+    }
+}

--- a/backend/src/main/kotlin/nl/nlportal/configurationpanel/configuration/NotifyConfigurationProperties.kt
+++ b/backend/src/main/kotlin/nl/nlportal/configurationpanel/configuration/NotifyConfigurationProperties.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nl.nlportal.configurationpanel.configuration
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "configuration-panel.notify")
+data class NotifyConfigurationProperties(
+    var notifyOnChanges: Boolean = false,
+    var notifyList: List<String> = emptyList(),
+)

--- a/backend/src/main/kotlin/nl/nlportal/configurationpanel/repository/ConfigRepository.kt
+++ b/backend/src/main/kotlin/nl/nlportal/configurationpanel/repository/ConfigRepository.kt
@@ -18,7 +18,9 @@ package nl.nlportal.configurationpanel.repository
 
 import nl.nlportal.configurationpanel.domain.ConfigurationProperty
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
+@Repository
 interface ConfigRepository : JpaRepository<ConfigurationProperty, String> {
 
     fun findByApplication(application: String): List<ConfigurationProperty>?

--- a/backend/src/main/kotlin/nl/nlportal/configurationpanel/service/ConfigService.kt
+++ b/backend/src/main/kotlin/nl/nlportal/configurationpanel/service/ConfigService.kt
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service
 @Service
 class ConfigService(
     private val configRepository: ConfigRepository,
+    private val notifyService: NotifyService
 ) {
 
     @Cacheable("configCache")
@@ -38,15 +39,22 @@ class ConfigService(
         return configRepository.findByApplication(application)
     }
 
-    fun getConfigurationPropertiesByApplicationAndFeatureKeyOrNull(application: String, featureKey: String): List<ConfigurationProperty>? {
+    fun getConfigurationPropertiesByApplicationAndFeatureKeyOrNull(
+        application: String,
+        featureKey: String
+    ): List<ConfigurationProperty>? {
         return configRepository.findByApplicationAndPropertyKeyStartsWith(application, featureKey)
     }
 
-    fun addConfigurationProperty(config: ConfigurationProperty): ConfigurationProperty? {
+    fun saveConfigurationProperty(config: ConfigurationProperty): ConfigurationProperty? {
         return configRepository.save(config)
     }
 
-    fun addConfigurationProperties(configs: List<ConfigurationProperty>): List<ConfigurationProperty> {
-        return configRepository.saveAll(configs)
+    fun saveConfigurationProperties(configs: List<ConfigurationProperty>): List<ConfigurationProperty> {
+        return configRepository
+            .saveAll(configs)
+            .also {
+                notifyService.restartNlPortalClients()
+            }
     }
 }

--- a/backend/src/main/kotlin/nl/nlportal/configurationpanel/service/NotifyService.kt
+++ b/backend/src/main/kotlin/nl/nlportal/configurationpanel/service/NotifyService.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nl.nlportal.configurationpanel.service
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import nl.nlportal.configurationpanel.client.NlPortalClient
+import nl.nlportal.configurationpanel.configuration.NotifyConfigurationProperties
+import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
+
+@Service
+class NotifyService(
+    private val notifyConfigurationProperties: NotifyConfigurationProperties,
+    private val nlPortalClient: NlPortalClient,
+) {
+
+    fun restartNlPortalClients() {
+        if (notifyConfigurationProperties.notifyOnChanges) {
+            notifyConfigurationProperties.notifyList.forEach {
+                try {
+                    nlPortalClient.restartNlPortalViaActuator(it)
+                } catch (e: HttpClientErrorException) {
+                    logger.debug(e) { "Failed to restart NLPalClient at url $it" }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+}

--- a/backend/src/main/kotlin/nl/nlportal/configurationpanel/web/rest/ConfigResource.kt
+++ b/backend/src/main/kotlin/nl/nlportal/configurationpanel/web/rest/ConfigResource.kt
@@ -55,7 +55,7 @@ class ConfigResource(
     }
 
     @PostMapping("/v1/configurations")
-    fun addConfigurationProperties(@RequestBody configs: List<ConfigurationProperty>): List<ConfigurationProperty> {
-        return configService.addConfigurationProperties(configs)
+    fun saveConfigurationProperties(@RequestBody configs: List<ConfigurationProperty>): List<ConfigurationProperty> {
+        return configService.saveConfigurationProperties(configs)
     }
 }

--- a/backend/src/main/resources/config/application.yml
+++ b/backend/src/main/resources/config/application.yml
@@ -1,48 +1,56 @@
 server:
-  port: 8888
+    port: 8888
+
+logging:
+    level:
+        root: info
 
 spring:
-  application:
-    name: configuration-panel-backend
-  cache:
-    type: simple
-  datasource:
-    type: com.zaxxer.hikari.HikariDataSource
-    driver-class-name: org.postgresql.Driver
-    url: # env var
-    username: # env var
-    password: # env var
-    name: nl-portal-config-database
-    hikari:
-      auto-commit: false
-      poolName: "nl-portal-config-pool"
-  liquibase:
-    change-log: classpath:/liquibase/config-master.xml
-  jpa:
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
-    database: postgresql
-    show_sql: false
-    open-in-view: false
-    properties:
-      hibernate:
-        hbm2ddl.auto: none
-        generate_statistics: false
-        naming-strategy: org.springframework.boot.orm.jpa.hibernate.SpringNamingStrategy
-        cache:
-          use_second_level_cache: false
-          use_query_cache: false
-          region.factory_class: org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
-        format_sql: true
-        jdbc:
-          time_zone: UTC
-        connection:
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          issuer-uri: ${JWT_ISSUER_URI}
+    application:
+        name: configuration-panel-backend
+    cache:
+        type: simple
+    datasource:
+        type: com.zaxxer.hikari.HikariDataSource
+        driver-class-name: org.postgresql.Driver
+        url: # env var
+        username: # env var
+        password: # env var
+        name: nl-portal-config-database
+        hikari:
+            auto-commit: false
+            poolName: "nl-portal-config-pool"
+    liquibase:
+        change-log: classpath:/liquibase/config-master.xml
+    jpa:
+        database-platform: org.hibernate.dialect.PostgreSQLDialect
+        database: postgresql
+        show_sql: false
+        open-in-view: false
+        properties:
+            hibernate:
+                hbm2ddl.auto: none
+                generate_statistics: false
+                naming-strategy: org.springframework.boot.orm.jpa.hibernate.SpringNamingStrategy
+                cache:
+                    use_second_level_cache: false
+                    use_query_cache: false
+                    region.factory_class: org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
+                format_sql: true
+                jdbc:
+                    time_zone: UTC
+                connection:
+    security:
+        oauth2:
+            resourceserver:
+                jwt:
+                    issuer-uri: ${JWT_ISSUER_URI}
+
 configuration-panel:
-  cache:
-    config-ttl: ${CONFIG_CACHE_TTL}
-  security:
-    token: ${CONFIGURATION_SERVER_TOKEN}
+    cache:
+        config-ttl: ${CONFIG_CACHE_TTL}
+    security:
+        token: ${CONFIG_SERVER_TOKEN}
+    notify:
+        notify-on-changes: ${CONFIG_NOTIFY_ENABLED:false}
+        notify-list: ${CONFIG_NOTIFY_LIST}

--- a/backend/src/main/resources/config/bootstrap.yml
+++ b/backend/src/main/resources/config/bootstrap.yml
@@ -1,14 +1,14 @@
 server:
-  port: 8888
+    port: 8888
 spring:
-  application:
-    name: configuration-panel
-  profiles:
-    default: jdbc
-  cloud:
-    config:
-      server:
-        jdbc:
-          sql: SELECT property_key as KEY, property_value as VALUE from nlp_configuration where application=? and (profile=? or label=?)
-          sql-without-profile: SELECT property_key as KEY, property_value as VALUE from nlp_configuration where application=? and (profile is null or label=?)
-        prefix: ${CONFIGURATION_SERVER_PREFIX}
+    application:
+        name: configuration-panel
+    profiles:
+        default: jdbc
+    cloud:
+        config:
+            server:
+                jdbc:
+                    sql: SELECT property_key as KEY, property_value as VALUE from nlp_configuration where application=? and (profile=? or label=?)
+                    sql-without-profile: SELECT property_key as KEY, property_value as VALUE from nlp_configuration where application=? and (profile is null or label=?)
+                prefix: ${CONFIG_SERVER_PREFIX}

--- a/backend/src/test/kotlin/nl/nlportal/configurationpanel/config/ConfigurationPanelCacheConfigurationTest.kt
+++ b/backend/src/test/kotlin/nl/nlportal/configurationpanel/config/ConfigurationPanelCacheConfigurationTest.kt
@@ -20,6 +20,7 @@ import nl.nlportal.configurationpanel.configuration.ConfigurationPanelCacheConfi
 import nl.nlportal.configurationpanel.domain.ConfigurationProperty
 import nl.nlportal.configurationpanel.repository.ConfigRepository
 import nl.nlportal.configurationpanel.service.ConfigService
+import nl.nlportal.configurationpanel.service.NotifyService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -36,11 +37,14 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.Instant
 
 @ExtendWith(SpringExtension::class)
-@SpringBootTest(classes = [
-    ConfigurationPanelCacheConfiguration::class,
-    ConfigService::class,
-    TestCacheConfiguration::class
-])
+@SpringBootTest(
+    classes = [
+        ConfigurationPanelCacheConfiguration::class,
+        ConfigService::class,
+        NotifyService::class,
+        TestCacheConfiguration::class
+    ]
+)
 class ConfigurationPanelCacheConfigurationTest {
 
     @Autowired
@@ -48,6 +52,9 @@ class ConfigurationPanelCacheConfigurationTest {
 
     @MockitoBean
     lateinit var configRepository: ConfigRepository
+
+    @MockitoBean
+    lateinit var notifyService: NotifyService
 
     @Test
     fun `test caching behavior`() {

--- a/backend/src/test/kotlin/nl/nlportal/configurationpanel/service/ConfigServiceTest.kt
+++ b/backend/src/test/kotlin/nl/nlportal/configurationpanel/service/ConfigServiceTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -22,13 +21,16 @@ class ConfigServiceTest {
     @Mock
     private lateinit var configRepository: ConfigRepository
 
-    @InjectMocks
+    @Mock
+    private lateinit var notifyService: NotifyService
+
     private lateinit var configService: ConfigService
 
     private lateinit var sampleConfig: ConfigurationProperty
 
     @BeforeEach
     fun setUp() {
+        configService = ConfigService(configRepository, notifyService)
         sampleConfig = ConfigurationProperty(
             propertyKey = "feature_123",
             propertyValue = "value1",
@@ -79,7 +81,7 @@ class ConfigServiceTest {
         `when`(configRepository.save(sampleConfig)).thenReturn(sampleConfig)
 
         // Act
-        val result = configService.addConfigurationProperty(sampleConfig)
+        val result = configService.saveConfigurationProperty(sampleConfig)
 
         // Assert
         assertNotNull(result)

--- a/backend/src/test/kotlin/nl/nlportal/configurationpanel/service/NotifyServiceTest.kt
+++ b/backend/src/test/kotlin/nl/nlportal/configurationpanel/service/NotifyServiceTest.kt
@@ -1,0 +1,64 @@
+package nl.nlportal.configurationpanel.service
+
+import nl.nlportal.configurationpanel.client.NlPortalClient
+import nl.nlportal.configurationpanel.configuration.NotifyConfigurationProperties
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class NotifyServiceTest {
+
+    @Mock
+    private lateinit var notifyConfigurationProperties: NotifyConfigurationProperties
+
+    @Mock
+    private lateinit var nlPortalClient: NlPortalClient
+
+    private lateinit var notifyService: NotifyService
+
+    @BeforeEach
+    fun setUp() {
+        notifyConfigurationProperties =
+            NotifyConfigurationProperties(
+                notifyOnChanges = true,
+                notifyList =
+                    listOf(
+                        "https://localhost:9001",
+                        "https://localhost:9002",
+                    )
+            )
+        nlPortalClient = mock()
+
+        notifyService = NotifyService(notifyConfigurationProperties, nlPortalClient)
+    }
+
+    @Test
+    fun `should notify all clients in notifyList`() {
+        // When
+        notifyService.restartNlPortalClients()
+
+        // Then
+        verify(nlPortalClient, times(2)).restartNlPortalViaActuator(any())
+    }
+
+    @Test
+    fun `should not notify if disabled`() {
+        // Given
+        notifyConfigurationProperties.notifyOnChanges = false
+
+        // When
+        notifyService.restartNlPortalClients()
+
+        // Then
+        verify(nlPortalClient, times(0)).restartNlPortalViaActuator(any())
+        assertEquals(2, notifyConfigurationProperties.notifyList.size)
+    }
+}

--- a/backend/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/backend/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
* renames env vars to be more consistent in preparation for docker image
* adds service and client that trigger the actuator restart endpoint of the nl portal spring boot application by base url
* fix mockito javaagent warning with java 21