### PR TITLE
fix: failing docker build and base image change

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
-FROM eclipse-temurin:21.0.6_7-jre-alpine
+FROM eclipse-temurin:21-jre-ubi10-minimal
 
-ADD build/libs/backend-0.1.0.jar /opt/app.jar
+ADD build/libs/backend.jar /opt/app.jar
 
 EXPOSE 8080
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 /*
  * Copyright 2025 Ritense BV, the Netherlands.
  *
@@ -98,4 +100,8 @@ tasks.bootRun {
 tasks.withType<Test> {
     useJUnitPlatform()
     jvmArgs("-javaagent:${mockitoAgent.asPath}")
+}
+
+tasks.named<BootJar>("bootJar") {
+    archiveFileName = "${project.name}.jar"
 }


### PR DESCRIPTION
* fixes failing docker build by making archivefilename consistent (version is irrelevant for the archive)
* change over to ubi10 based java 21 image due to vulnerabilities in alpine and smaller image size